### PR TITLE
SourceNavigation streamline

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/mapping-card.tsx
@@ -71,11 +71,6 @@ const MappingCard: React.FC<Props> = (props) => {
   //For storing docURIs
   const [docUris, setDocUris] = useState<any[]>([]);
 
-  //For handling docUris navigation
-  const [disableURINavLeft, setDisableURINavLeft] = useState(true);
-  const [disableURINavRight, setDisableURINavRight] = useState(false);
-
-
   //For storing  mapping functions
   const [mapFunctions, setMapFunctions] = useState([]);
 
@@ -178,7 +173,6 @@ const MappingCard: React.FC<Props> = (props) => {
       let response = await getUris(stepName, 20);
       if (response.status === 200) {
         if (response.data.length > 0) {
-          setDisableURINavRight(response.data.length > 1 ? false : true);
           setDocUris(response.data);
           setSourceURI(response.data[0]);
           fetchSrcDocFromUri(stepName, response.data[0]);
@@ -855,10 +849,6 @@ const MappingCard: React.FC<Props> = (props) => {
         extractCollectionFromSrcQuery={extractCollectionFromSrcQuery}
         fetchSrcDocFromUri={fetchSrcDocFromUri}
         docUris={docUris}
-        disableURINavLeft={disableURINavLeft}
-        disableURINavRight={disableURINavRight}
-        setDisableURINavLeft={setDisableURINavLeft}
-        setDisableURINavRight={setDisableURINavRight}
         sourceDatabaseName={sourceDatabaseName}
         mapFunctions={mapFunctions}
         namespaces={namespaces}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.module.scss
@@ -421,62 +421,6 @@ hr {
     margin-top: 4px;
 }
 
-.navigate_source_uris{
-    width: 115px;
-    display: flex;
-    align-content: center ;
-    vertical-align: bottom;
-    justify-content: space-between;
-    text-align: center;
-    margin-top: -32px;
-    margin-left: 45%;
-    white-space: nowrap;
-  }
- .navigate_uris_left {
-    user-select: none;
-    cursor: pointer;
-    width: 2vw;
-    text-align: center;
-    align-content: center ;
-    justify-content: center;
-    background:none;
-    outline: none !important;
-    > .navigateIcon {
-        display: block;
-        margin-left: -6px;
-    }
-  }
-  .URI_Index{
-    > p {
-    border: 1px solid #7F86B5;
-    border-radius: 4px;
-    background-color: #7F86B5;
-    color: #ffffff;
-    width: 32px;
-    height: 32px;
-    padding-top: 4px;
-
-    font-size: 15px;
-
-    }
-  }
-
-  .navigate_uris_right {
-    user-select: none;
-    cursor: pointer;
-    width: 2vw;
-    background:none;
-    outline: none !important;
-    text-align: center;
-    outline: none;
-    align-content: center ;
-    justify-content: center;
-    > .navigateIcon {
-        display: block;
-        margin-left: -6px;
-    }
-  }
-
 .spinRunning {
     position: absolute;
     padding-top: 100px;

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.test.tsx
@@ -804,7 +804,7 @@ describe("RTL Source-to-entity map tests", () => {
 
     // Click next, URI index is 2
     fireEvent.click(getByTestId("navigate-uris-right"));
-    uriIndex = within(getByLabelText("uriIndex"));
+    uriIndex = await waitForElement(() => within(getByLabelText("uriIndex")));
     expect(uriIndex.getByText("2")).toBeInTheDocument();
 
     // Close mapping modal
@@ -1139,5 +1139,34 @@ describe("RTL Source Selector/Source Search tests", () => {
     //Right Xpath is populated (and not nutFreeName/FirstNamePreferred since sourceContext is set)
     expect(mapExp).toHaveTextContent("FirstNamePreferred");
   });
+
+  test("Verify the index value changes correspondently to left or right document uri button click",  async() => {
+    const {getByLabelText, getByTestId} = render(<SourceToEntityMap {...data.mapProps}  mappingVisible={true}/>);
+
+    // URI index starts at 1
+    let uriIndex = within(getByLabelText("uriIndex"));
+    expect(uriIndex.getByText("1")).toBeInTheDocument();
+
+    // Click next, URI index is 2
+    fireEvent.click(getByTestId("navigate-uris-right"));
+    uriIndex = await waitForElement(() => within(getByLabelText("uriIndex")));
+    expect(uriIndex.getByText("2")).toBeInTheDocument();
+
+    // Click next, URI index is 3
+    fireEvent.click(getByTestId("navigate-uris-right"));
+    uriIndex = await waitForElement(() => within(getByLabelText("uriIndex")));
+    expect(uriIndex.getByText("3")).toBeInTheDocument();
+
+    // Click previous, URI index is 2
+    fireEvent.click(getByTestId("navigate-uris-left"));
+    uriIndex = await waitForElement(() => within(getByLabelText("uriIndex")));
+    expect(uriIndex.getByText("2")).toBeInTheDocument();
+
+    // Click previous, URI index is 1
+    fireEvent.click(getByTestId("navigate-uris-left"));
+    uriIndex = await waitForElement(() => within(getByLabelText("uriIndex")));
+    expect(uriIndex.getByText("1")).toBeInTheDocument();
+  });
+
 });
 

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -206,13 +206,10 @@ const SourceToEntityMap = (props) => {
 
   //To handle navigation buttons
   const onNavigateURIList = (index) => {
-    const end = props.docUris.length - 1;
-    if (index >= 0 && index <= end) {
-      onUpdateURINavButtons(props.docUris[index]).then(() => {
-        setUriIndex(index);
-        setSrcURI(props.docUris[index]);
-      });
-    }
+    onUpdateURINavButtons(props.docUris[index]).then(() => {
+      setUriIndex(index);
+      setSrcURI(props.docUris[index]);
+    });
   };
   const onUpdateURINavButtons = async (uri) => {
     await props.fetchSrcDocFromUri(props.mapData.name, uri, props.mapIndex);

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx
@@ -11,6 +11,7 @@ import DropDownWithSearch from "../../../common/dropdown-with-search/dropdownWit
 import SplitPane from "react-split-pane";
 import Highlighter from "react-highlight-words";
 import {MLButton, MLTooltip, MLCheckbox, MLSpin} from "@marklogic/design-system";
+import SourceNavigation from "../source-navigation/source-navigation";
 
 const SourceToEntityMap = (props) => {
 
@@ -206,58 +207,21 @@ const SourceToEntityMap = (props) => {
   //To handle navigation buttons
   const onNavigateURIList = (index) => {
     const end = props.docUris.length - 1;
-    // Not at beginning or end of range
-    if (index > 0 && index < end) {
-      props.setDisableURINavLeft(false);
-      props.setDisableURINavRight(false);
-      setUriIndex(index);
-      setSrcURI(props.docUris[index]);
-      onUpdateURINavButtons(props.docUris[index]);
-
-    } else if (index === 0) { // At beginning of range
-      props.setDisableURINavLeft(true);
-      if (end > 0) {
-        props.setDisableURINavRight(false);
-      }
-      setUriIndex(index);
-      setSrcURI(props.docUris[index]);
-      onUpdateURINavButtons(props.docUris[index]);
-    } else if (index === end) { // At end of range
-      if (end > 0) {
-        props.setDisableURINavLeft(false);
-      }
-      props.setDisableURINavRight(true);
-      setUriIndex(index);
-      setSrcURI(props.docUris[index]);
-      onUpdateURINavButtons(props.docUris[index]);
-    } else {
-      if (index < 0) {      // Before beginning of range
-        props.setDisableURINavLeft(true);
-      } else {       // After end of range
-        props.setDisableURINavRight(true);
-      }
+    if (index >= 0 && index <= end) {
+      onUpdateURINavButtons(props.docUris[index]).then(() => {
+        setUriIndex(index);
+        setSrcURI(props.docUris[index]);
+      });
     }
   };
-  const onUpdateURINavButtons = (uri) => {
-    props.fetchSrcDocFromUri(props.mapData.name, uri, props.mapIndex);
+  const onUpdateURINavButtons = async (uri) => {
+    await props.fetchSrcDocFromUri(props.mapData.name, uri, props.mapIndex);
     if (isTestClicked) {
       getMapValidationResp(uri);
     }
   };
 
-  const navigationButtons = <span className={styles.navigate_source_uris}>
-    <MLButton className={styles.navigate_uris_left} data-testid="navigate-uris-left" onClick={() => onNavigateURIList(uriIndex - 1)} disabled={props.disableURINavLeft}>
-      <Icon type="left" className={styles.navigateIcon} />
-    </MLButton>
-        &nbsp;
-    <div aria-label="uriIndex" className={styles.URI_Index}><p>{uriIndex + 1}</p></div>
-        &nbsp;
-    <MLButton className={styles.navigate_uris_right} data-testid="navigate-uris-right" onClick={() => onNavigateURIList(uriIndex + 1)} disabled={props.disableURINavRight}>
-      <Icon type="right" className={styles.navigateIcon} />
-    </MLButton>
-  </span>;
-
-  //Code for navigation buttons ends here
+  const navigationButtons = <SourceNavigation currentIndex={uriIndex} startIndex={0} endIndex={props.docUris && props.docUris.length - 1} handleSelection={onNavigateURIList} />;
 
   //Set the mapping expressions, if already exists.
   const initializeMapExpressions = () => {

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.module.scss
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.module.scss
@@ -1,0 +1,56 @@
+.navigate_source_uris{
+  width: 115px;
+  display: flex;
+  align-content: center ;
+  vertical-align: bottom;
+  justify-content: space-between;
+  text-align: center;
+  margin-top: -32px;
+  margin-left: 45%;
+  white-space: nowrap;
+}
+
+.navigate_uris_left {
+  user-select: none;
+  cursor: pointer;
+  width: 2vw;
+  text-align: center;
+  align-content: center ;
+  justify-content: center;
+  background:none;
+  outline: none !important;
+  > .navigateIcon {
+      display: block;
+      margin-left: -6px;
+  }
+}
+.URI_Index{
+  > p {
+  border: 1px solid #7F86B5;
+  border-radius: 4px;
+  background-color: #7F86B5;
+  color: #ffffff;
+  width: 32px;
+  height: 32px;
+  padding-top: 4px;
+
+  font-size: 15px;
+
+  }
+}
+
+.navigate_uris_right {
+  user-select: none;
+  cursor: pointer;
+  width: 2vw;
+  background:none;
+  outline: none !important;
+  text-align: center;
+  outline: none;
+  align-content: center ;
+  justify-content: center;
+  > .navigateIcon {
+      display: block;
+      margin-left: -6px;
+  }
+}

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.test.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {render, fireEvent, within, waitForElement} from "@testing-library/react";
+import SourceNavigation from "./source-navigation";
+
+describe("Source Navigation component tests", () => {
+
+  test("Verify left navigation button is disabled when first document is selected", () => {
+    const {getByLabelText, getByTestId} = render(<SourceNavigation currentIndex={0} startIndex={0} endIndex={2} handleSelection={jest.fn()} />);
+
+    let uriIndex = within(getByLabelText("uriIndex"));
+    let leftNavButton = getByTestId("navigate-uris-left");
+    let rightNavButton = getByTestId("navigate-uris-right");
+
+    expect(uriIndex.getByText("1")).toBeInTheDocument();
+    expect(leftNavButton).toBeDisabled();
+    expect(rightNavButton).toBeEnabled();
+
+  });
+
+  test("Verify right navigation button is disabled when last document is selected", () => {
+    const {getByLabelText, getByTestId} = render(<SourceNavigation currentIndex={2} startIndex={0} endIndex={2} handleSelection={jest.fn()} />);
+
+    let uriIndex = within(getByLabelText("uriIndex"));
+    let leftNavButton = getByTestId("navigate-uris-left");
+    let rightNavButton = getByTestId("navigate-uris-right");
+
+    expect(uriIndex.getByText("3")).toBeInTheDocument();
+    expect(leftNavButton).toBeEnabled();
+    expect(rightNavButton).toBeDisabled();
+  });
+
+  test("Verify left and right navigation buttons are disabled when only one documet exists", () => {
+    const {getByLabelText, getByTestId} = render(<SourceNavigation currentIndex={0} startIndex={0} endIndex={0} handleSelection={jest.fn()} />);
+
+    let uriIndex = within(getByLabelText("uriIndex"));
+    let leftNavButton = getByTestId("navigate-uris-left");
+    let rightNavButton = getByTestId("navigate-uris-right");
+
+    expect(uriIndex.getByText("1")).toBeInTheDocument();
+    expect(leftNavButton).toBeDisabled();
+    expect(rightNavButton).toBeDisabled();
+  });
+
+  test("Verify left and right navigation buttons are enabled when middle document is selected", () => {
+    const {getByLabelText, getByTestId} = render(<SourceNavigation currentIndex={1} startIndex={0} endIndex={2} handleSelection={jest.fn()} />);
+
+    let uriIndex = within(getByLabelText("uriIndex"));
+    let leftNavButton = getByTestId("navigate-uris-left");
+    let rightNavButton = getByTestId("navigate-uris-right");
+
+    expect(uriIndex.getByText("2")).toBeInTheDocument();
+    expect(leftNavButton).toBeEnabled();
+    expect(rightNavButton).toBeEnabled();
+  });
+
+  test("Verify handleSelection is called with correct index", () => {
+    const handleSelectionMock = jest.fn();
+    const {getByTestId} = render(<SourceNavigation currentIndex={1} startIndex={0} endIndex={2} handleSelection={handleSelectionMock} />);
+
+    fireEvent.click(getByTestId("navigate-uris-left"));
+    expect(handleSelectionMock).toHaveBeenCalledTimes(1);
+    expect(handleSelectionMock).toHaveBeenLastCalledWith(0);
+
+    fireEvent.click(getByTestId("navigate-uris-right"));
+    expect(handleSelectionMock).toHaveBeenCalledTimes(2);
+    expect(handleSelectionMock).toHaveBeenLastCalledWith(2);
+  });
+
+});

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.tsx
@@ -12,18 +12,25 @@ interface Props {
 
 const SourceNavigation: React.FC<Props> = (props) => {
 
-  let leftNavButtonDisabled = props.currentIndex === 0 && props.currentIndex === props.startIndex;
-  let rightNavButtonDisabled = props.endIndex < 0 || props.currentIndex === props.endIndex;
-
   return (
     <span className={styles.navigate_source_uris}>
-      <MLButton className={styles.navigate_uris_left} data-testid="navigate-uris-left" onClick={() => props.handleSelection(props.currentIndex - 1)} disabled={leftNavButtonDisabled}>
+      <MLButton 
+        className={styles.navigate_uris_left} 
+        data-testid="navigate-uris-left" 
+        onClick={() => props.handleSelection(props.currentIndex - 1)} 
+        disabled={props.currentIndex === props.startIndex}
+      >
         <Icon type="left" className={styles.navigateIcon} />
       </MLButton>
         &nbsp;
       <div aria-label="uriIndex" className={styles.URI_Index}><p>{props.currentIndex + 1}</p></div>
         &nbsp;
-      <MLButton className={styles.navigate_uris_right} data-testid="navigate-uris-right" onClick={() => props.handleSelection(props.currentIndex + 1)} disabled={rightNavButtonDisabled}>
+      <MLButton 
+        className={styles.navigate_uris_right} 
+        data-testid="navigate-uris-right" 
+        onClick={() => props.handleSelection(props.currentIndex + 1)} 
+        disabled={props.currentIndex === props.endIndex}
+      >
         <Icon type="right" className={styles.navigateIcon} />
       </MLButton>
     </span>

--- a/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.tsx
+++ b/marklogic-data-hub-central/ui/src/components/entities/mapping/source-navigation/source-navigation.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import {Icon} from "antd";
+import {MLButton} from "@marklogic/design-system";
+import styles from "./source-navigation.module.scss";
+
+interface Props {
+  currentIndex: number;
+  startIndex: number;
+  endIndex: number;
+  handleSelection: (index: number) => void;
+}
+
+const SourceNavigation: React.FC<Props> = (props) => {
+
+  let leftNavButtonDisabled = props.currentIndex === 0 && props.currentIndex === props.startIndex;
+  let rightNavButtonDisabled = props.endIndex < 0 || props.currentIndex === props.endIndex;
+
+  return (
+    <span className={styles.navigate_source_uris}>
+      <MLButton className={styles.navigate_uris_left} data-testid="navigate-uris-left" onClick={() => props.handleSelection(props.currentIndex - 1)} disabled={leftNavButtonDisabled}>
+        <Icon type="left" className={styles.navigateIcon} />
+      </MLButton>
+        &nbsp;
+      <div aria-label="uriIndex" className={styles.URI_Index}><p>{props.currentIndex + 1}</p></div>
+        &nbsp;
+      <MLButton className={styles.navigate_uris_right} data-testid="navigate-uris-right" onClick={() => props.handleSelection(props.currentIndex + 1)} disabled={rightNavButtonDisabled}>
+        <Icon type="right" className={styles.navigateIcon} />
+      </MLButton>
+    </span>
+  );
+};
+
+export default SourceNavigation;


### PR DESCRIPTION
If we assume the following constraints: startIndex <= currentIndex <= endIndex

Then I think we can streamline the code to make it easier to understand. 

If the above constraint is followed, and the SourceNavigation component checks for the edge cases, then the SourceNavigation component will never pass back bad index information.